### PR TITLE
Fix layout issues caused by large carousel

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,6 +8,8 @@ img {
   border-radius: 1rem;
 }
 
-body {
-  height: 100vh;
+@media only screen and (min-width: 992px) {
+  .carousel {
+    width: 57%;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
 
   
 
-  <body class="container-fluid d-flex flex-column justify-content-center align-items-center bg-secondary bg-opacity-25 p-lg-5">
+  <body class="container-fluid bg-secondary bg-opacity-25 p-1">
 
-    <div>
+    <div class="container">
       <h1 class="display-6 text-center">Mushroom's Mysterious Trip</h1>
     </div>
     
@@ -44,8 +44,7 @@
       <div class="carousel-inner">
         <!-- First carousel item -->
         <div class="carousel-item active">
-          <!-- <img src="./img/mush01.jpg" class="d-block w-100" alt="Mushroom the Cat in a carrier"> -->
-          <img src="https://images.unsplash.com/photo-1647002380358-fc70ed2f04e0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80" class="d-block w-100" alt="Mushroom the Cat in a carrier">
+          <img src="./img/mush01.jpg" class="d-block w-100" alt="Mushroom the Cat in a carrier">
           <div class="carousel-caption d-none d-md-block">
             <div class="bg-dark bg-opacity-50 rounded-3">
               <h5>Mushroom in a carrier</h5>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
       <div class="carousel-inner">
         <!-- First carousel item -->
         <div class="carousel-item active">
-          <img src="./img/mush01.jpg" class="d-block w-100" alt="Mushroom the Cat in a carrier">
+          <!-- <img src="./img/mush01.jpg" class="d-block w-100" alt="Mushroom the Cat in a carrier"> -->
+          <img src="https://images.unsplash.com/photo-1647002380358-fc70ed2f04e0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80" class="d-block w-100" alt="Mushroom the Cat in a carrier">
           <div class="carousel-caption d-none d-md-block">
             <div class="bg-dark bg-opacity-50 rounded-3">
               <h5>Mushroom in a carrier</h5>
@@ -84,7 +85,7 @@
         </div>
         <!-- Fifth carousel item -->
         <div class="carousel-item">
-          <img src="./img/mush05.jpg" class="d-block w-100" alt="Maya the Cat on a windowsill with her fur standing on end">
+          <img src="./img/mush05.jpg" class="d-block w-100" alt="Maya the cat on a windowsill with her fur standing on end">
           <div class="carousel-caption d-none d-md-block">
             <div class="bg-dark bg-opacity-50 rounded-3">
               <h5>Maya claims the high ground...</h5>


### PR DESCRIPTION
**Changes**
- Added a media query for large screens (992px breakpoint) that resizes the carousel width to 57% so that the heading isn't pushed off the page and the entire carousel is visible.

Closes #1.